### PR TITLE
Improve selectors and logging

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,16 +8,23 @@ function removeConnections() {
   const cards = Array.from(document.querySelectorAll('li.mn-connection-card'));
   (async () => {
     for (const card of cards) {
-      const moreBtn = card.querySelector('button[aria-label*="More actions"], button[aria-label*="Plus d\u2019actions"]');
+      const moreBtn = card.querySelector(
+        "button[aria-label*='More actions'], button[aria-label*='Plus d\\u2019actions'], button[aria-label*='Plus d\\'actions']"
+      );
       if (moreBtn) {
+        console.log("Opening actions menu for", card);
         moreBtn.click();
         await wait(500);
-        const removeBtn = document.querySelector('div[role="menu"] button[aria-label*="Remove connection"], div[role="menu"] button[aria-label*="Retirer la relation"]');
+        const removeBtn = document.querySelector('div[role="menu"] button[aria-label*="Remove connection"], div[role="menu"] button[aria-label*="Retirer la relation"], div[role="menu"] button[aria-label*="Supprimer la relation"]');
         if (removeBtn) {
+          console.log("Removing connection");
           removeBtn.click();
           await wait(500);
-          const confirmBtn = document.querySelector('button.artdeco-button--danger, button[aria-label*="Remove"], button[aria-label*="Retirer"]');
-          if (confirmBtn) confirmBtn.click();
+          const confirmBtn = document.querySelector('button.artdeco-button--danger, button[aria-label*="Remove"], button[aria-label*="Retirer"], button[aria-label*="Supprimer"]');
+          if (confirmBtn) {
+            console.log('Confirming removal');
+            confirmBtn.click();
+          }
         }
       }
       await wait(randomDelay());


### PR DESCRIPTION
## Summary
- account for `'` vs `’` in selectors
- add fallback selectors for the French wording
- emit console logs when removing connections

## Testing
- `node -c background.js`


------
https://chatgpt.com/codex/tasks/task_b_685ed44fbc38832f8a0a3f423ffe4b44