### PR TITLE
Améliore l'interface et ajoute le contrôle du nettoyage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ LinkedIn Cleaner est une extension Chrome minimaliste qui aide à gérer et nett
 
 ## Utilisation
 1. Naviguez vers votre page de connexions LinkedIn : `https://www.linkedin.com/mynetwork/invite-connect/connections/`.
-2. Cliquez sur l'icône de l'extension et appuyez sur **Nettoyer cette page**.
-3. Les contacts visibles seront retirés un par un avec confirmation automatique. Rechargez la page pour traiter un nouveau lot si nécessaire.
+2. Cliquez sur l'icône de l'extension puis sur **Commencer** pour lancer la suppression automatique.
+3. Utilisez **Pause** ou **Arrêter** pour contrôler le processus. Les contacts visibles seront retirés un par un. Rechargez la page pour traiter un nouveau lot si nécessaire.
 
 ## À qui s'adresse cette extension ?
 - Les professionnels en transition de carrière qui souhaitent réorienter leur réseau.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ LinkedIn Cleaner est une extension Chrome minimaliste qui aide à gérer et nett
 - Toute personne soucieuse de la qualité plutôt que de la quantité.
 
 ## Fonctionnement
-L'extension vérifie que vous êtes bien sur la page des connexions avant de lancer le script. Elle ouvre le menu d'actions de chaque contact, clique sur **Retirer la relation**, confirme la suppression et attend 1,5 à 2 secondes entre chaque contact pour reproduire un rythme humain. La logique d'injection est désormais gérée par un *service worker* pour plus de fiabilité.
+L'extension vérifie que vous êtes bien sur la page des connexions avant de lancer le script. Elle ouvre le menu d'actions de chaque contact, clique sur **Retirer la relation**, confirme la suppression et attend 1,5 à 2 secondes entre chaque contact pour reproduire un rythme humain. La logique d'injection est désormais gérée par un *service worker* pour plus de fiabilité, et le processus s'interrompt automatiquement lorsque vous quittez la page des connexions.

--- a/background.js
+++ b/background.js
@@ -40,11 +40,15 @@ function startCleaning(tabId, delay) {
           if (paused) { setTimeout(process, 500); return; }
           if (index >= cards.length) { window.liCleanerState.status = 'completed'; return; }
           const card = cards[index];
-          const moreBtn = card.querySelector("button[aria-label*='More actions'], button[aria-label*='Plus d\u2019actions'], button[aria-label*=\"Plus d'action\"]");
+          const moreBtn = card.querySelector("button.mn-connection-card__dropdown-trigger, button[aria-label*='More actions'], button[aria-label*='Plus d\u2019actions'], button[aria-label*=\"Plus d'action\"]");
           if (moreBtn) {
             moreBtn.click();
             await wait(500);
-            const removeBtn = document.querySelector("div[role='menu'] button[aria-label*='Remove connection'], div[role='menu'] button[aria-label*='Retirer la relation'], div[role='menu'] button[aria-label*='Supprimer la relation']");
+            const removeBtn = Array.from(document.querySelectorAll("button"))
+              .find(b => {
+                const l = b.getAttribute('aria-label') || '';
+                return /Supprimer.*relation|Retirer.*relation|Remove.*connection/i.test(l);
+              });
             if (removeBtn) {
               removeBtn.click();
               await wait(500);

--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@ function startCleaning(tabId, delay) {
   chrome.scripting.executeScript({
     target: { tabId },
     func: (d) => {
-      (function(delay) {
+      (async function run(delay) {
         if (location.href.indexOf('linkedin.com/mynetwork/invite-connect/connections/') === -1) {
           alert('Redirection vers la page de connexions...');
           location.href = 'https://www.linkedin.com/mynetwork/invite-connect/connections/';
@@ -11,7 +11,16 @@ function startCleaning(tabId, delay) {
         if (window.liCleaner && window.liCleaner.stop) {
           window.liCleaner.stop();
         }
-        const cards = Array.from(document.querySelectorAll('li.mn-connection-card'));
+        const wait = ms => new Promise(r => setTimeout(r, ms));
+        async function waitForCards() {
+          for (let i = 0; i < 20; i++) {
+            const found = document.querySelectorAll('li.mn-connection-card');
+            if (found.length) return Array.from(found);
+            await wait(500);
+          }
+          return [];
+        }
+        const cards = await waitForCards();
         let index = 0;
         let paused = false;
         let stopped = false;
@@ -26,7 +35,6 @@ function startCleaning(tabId, delay) {
             window.liCleanerState.status = 'stopped';
           }
         };
-        const wait = ms => new Promise(r => setTimeout(r, ms));
         const process = async () => {
           if (stopped) return;
           if (paused) { setTimeout(process, 500); return; }

--- a/background.js
+++ b/background.js
@@ -35,6 +35,18 @@ function startCleaning(tabId, delay) {
             window.liCleanerState.status = 'stopped';
           }
         };
+
+        // stop the process if the user navigates away from the connections page
+        const pageCheck = setInterval(() => {
+          if (location.href.indexOf('linkedin.com/mynetwork/invite-connect/connections/') === -1) {
+            window.liCleaner.stop();
+            clearInterval(pageCheck);
+          }
+        }, 500);
+        window.addEventListener('beforeunload', () => {
+          window.liCleaner.stop();
+          clearInterval(pageCheck);
+        });
         const process = async () => {
           if (stopped) return;
           if (paused) { setTimeout(process, 500); return; }

--- a/background.js
+++ b/background.js
@@ -1,75 +1,93 @@
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-  if (message.action === 'clean') {
-    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
-      var tab = tabs[0];
-      if (!tab || !tab.url || !tab.url.includes('linkedin.com/mynetwork/invite-connect/connections/')) {
-        chrome.scripting.executeScript({
-          target: { tabId: tab.id },
-          func: function() { alert('Veuillez naviguer vers votre page de connexions LinkedIn.'); }
-        }, function() {
-          sendResponse();
-        });
-        return true; // Keep the message channel open for async response
-      }
-      chrome.scripting.executeScript({
-        target: { tabId: tab.id },
-        func: function() {
-          function wait(ms) {
-            return new Promise(function(resolve) { setTimeout(resolve, ms); });
-          }
-          function randomDelay() { return 1500 + Math.random() * 500; }
-          if (!location.href.includes('linkedin.com/mynetwork/invite-connect/connections/')) {
-            alert('Veuillez naviguer vers votre page de connexions LinkedIn.');
-            return;
-          }
-          var cards = Array.prototype.slice.call(document.querySelectorAll('li.mn-connection-card'));
-
-          function processCard(i) {
-            if (i >= cards.length) {
-              return;
-            }
-            var card = cards[i];
-            var moreBtn = card.querySelector(
-              "button[aria-label*='More actions'], button[aria-label*='Plus d\\u2019actions'], button[aria-label*=\"Plus d'action\"]"
-            );
-            function continueNext() {
-              wait(randomDelay()).then(function() { processCard(i + 1); });
-            }
-            if (moreBtn) {
-              console.log('Opening actions menu for', card);
-              moreBtn.click();
-              wait(500).then(function() {
-                var removeBtn = document.querySelector(
-                  "div[role='menu'] button[aria-label*='Remove connection'], div[role='menu'] button[aria-label*='Retirer la relation'], div[role='menu'] button[aria-label*='Supprimer la relation']"
-                );
-                if (removeBtn) {
-                  console.log('Removing connection');
-                  removeBtn.click();
-                  wait(500).then(function() {
-                    var confirmBtn = document.querySelector(
-                      "button.artdeco-button--danger, button[aria-label*='Remove'], button[aria-label*='Retirer'], button[aria-label*='Supprimer']"
-                    );
-                    if (confirmBtn) {
-                      console.log('Confirming removal');
-                      confirmBtn.click();
-                    }
-                    continueNext();
-                  });
-                } else {
-                  continueNext();
-                }
-              });
-            } else {
-              continueNext();
-            }
-          }
-
-          processCard(0);
+function startCleaning(tabId, delay) {
+  chrome.scripting.executeScript({
+    target: { tabId },
+    func: (d) => {
+      (function(delay) {
+        if (location.href.indexOf('linkedin.com/mynetwork/invite-connect/connections/') === -1) {
+          alert('Redirection vers la page de connexions...');
+          location.href = 'https://www.linkedin.com/mynetwork/invite-connect/connections/';
+          return;
         }
-      }, function() {
+        if (window.liCleaner && window.liCleaner.stop) {
+          window.liCleaner.stop();
+        }
+        const cards = Array.from(document.querySelectorAll('li.mn-connection-card'));
+        let index = 0;
+        let paused = false;
+        let stopped = false;
+        window.liCleanerState = { status: 'running', removed: 0, total: cards.length };
+        window.liCleaner = {
+          pause() {
+            paused = !paused;
+            window.liCleanerState.status = paused ? 'paused' : 'running';
+          },
+          stop() {
+            stopped = true;
+            window.liCleanerState.status = 'stopped';
+          }
+        };
+        const wait = ms => new Promise(r => setTimeout(r, ms));
+        const process = async () => {
+          if (stopped) return;
+          if (paused) { setTimeout(process, 500); return; }
+          if (index >= cards.length) { window.liCleanerState.status = 'completed'; return; }
+          const card = cards[index];
+          const moreBtn = card.querySelector("button[aria-label*='More actions'], button[aria-label*='Plus d\u2019actions'], button[aria-label*=\"Plus d'action\"]");
+          if (moreBtn) {
+            moreBtn.click();
+            await wait(500);
+            const removeBtn = document.querySelector("div[role='menu'] button[aria-label*='Remove connection'], div[role='menu'] button[aria-label*='Retirer la relation'], div[role='menu'] button[aria-label*='Supprimer la relation']");
+            if (removeBtn) {
+              removeBtn.click();
+              await wait(500);
+              const confirmBtn = document.querySelector("button.artdeco-button--danger, button[aria-label*='Remove'], button[aria-label*='Retirer'], button[aria-label*='Supprimer']");
+              if (confirmBtn) confirmBtn.click();
+            }
+          }
+          index++;
+          window.liCleanerState.removed = index;
+          setTimeout(process, delay);
+        };
+        process();
+      })(d);
+    },
+    args: [delay]
+  });
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (['start', 'pause', 'stop', 'status'].includes(message.action)) {
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      const tab = tabs[0];
+      if (!tab) { sendResponse(); return; }
+      if (message.action === 'start') {
+        const correct = tab.url && tab.url.includes('linkedin.com/mynetwork/invite-connect/connections/');
+        if (!correct) {
+          chrome.scripting.executeScript({ target: { tabId: tab.id }, func: () => alert('Redirection vers la page de connexions...') });
+          chrome.tabs.update(tab.id, { url: 'https://www.linkedin.com/mynetwork/invite-connect/connections/' });
+          chrome.tabs.onUpdated.addListener(function listener(id, info) {
+            if (id === tab.id && info.status === 'complete') {
+              chrome.tabs.onUpdated.removeListener(listener);
+              startCleaning(tab.id, message.delay);
+            }
+          });
+          sendResponse({ status: 'redirecting' });
+        } else {
+          startCleaning(tab.id, message.delay);
+          sendResponse({ status: 'running' });
+        }
+      } else if (message.action === 'pause') {
+        chrome.scripting.executeScript({ target: { tabId: tab.id }, func: () => { window.liCleaner && window.liCleaner.pause(); } });
         sendResponse();
-      });
-      return true; // Keep the message channel open for async response
+      } else if (message.action === 'stop') {
+        chrome.scripting.executeScript({ target: { tabId: tab.id }, func: () => { window.liCleaner && window.liCleaner.stop(); } });
+        sendResponse();
+      } else if (message.action === 'status') {
+        chrome.scripting.executeScript({ target: { tabId: tab.id }, func: () => window.liCleanerState || null }, res => {
+          sendResponse(res && res[0] ? res[0].result : null);
+        });
+        return true;
+      }
     });
     return true;
   }

--- a/popup.html
+++ b/popup.html
@@ -2,38 +2,43 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <title>LinkedIn Cleaner</title>
+  <title>Suppression automatique des connexions LinkedIn</title>
   <style>
-    body {
-      font-family: Arial, sans-serif;
-      width: 220px;
-      padding: 12px;
-      background: #f3f4f6;
-    }
-    h1 {
-      font-size: 16px;
-      margin: 0 0 10px 0;
-      text-align: center;
-      color: #0073b1;
-    }
-    button {
-      width: 100%;
-      padding: 8px;
-      font-size: 14px;
-      background-color: #0073b1;
-      border: none;
-      color: white;
-      border-radius: 4px;
-      cursor: pointer;
-    }
-    button:hover {
-      background-color: #005f8d;
-    }
+    body { font-family: Arial, sans-serif; width: 300px; padding: 15px; background:#ffffff; color:#333; position:relative; }
+    h1 { font-size:18px; color:#0073b1; text-align:center; margin-top:0; }
+    label { font-size:14px; display:block; margin-bottom:4px; }
+    select { width:100%; padding:5px; margin-bottom:10px; }
+    .controls { display:flex; justify-content:space-between; margin-bottom:10px; }
+    button { flex:1; margin:0 2px; padding:8px; border:none; border-radius:4px; color:#fff; font-size:14px; cursor:pointer; }
+    #start { background:#28a745; }
+    #pause { background:#ff9800; }
+    #stop { background:#d32f2f; }
+    #close { position:absolute; top:5px; right:5px; border:none; background:none; font-size:16px; cursor:pointer; color:#999; }
+    #close:hover { color:#333; }
+    progress { width:100%; height:18px; margin-top:5px; }
+    .status { text-align:center; margin-top:5px; font-size:14px; }
   </style>
 </head>
 <body>
-  <h1>LinkedIn Cleaner</h1>
-  <button id="clean">Nettoyer cette page</button>
+  <button id="close">&times;</button>
+  <h1>Suppression automatique des connexions LinkedIn</h1>
+  <label for="delay">Délai entre suppressions</label>
+  <select id="delay">
+    <option value="1000">1s</option>
+    <option value="2000">2s</option>
+    <option value="3000">3s</option>
+    <option value="5000">5s</option>
+    <option value="10000">10s</option>
+  </select>
+  <div class="controls">
+    <button id="start">Commencer</button>
+    <button id="pause">Pause</button>
+    <button id="stop">Arrêter</button>
+  </div>
+  <progress id="progress" value="0" max="0"></progress>
+  <div class="status">
+    <span id="counter">0/0</span> - <span id="state">En attente</span>
+  </div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,51 @@
-document.getElementById('clean').addEventListener('click', () => {
-  chrome.runtime.sendMessage({ action: 'clean' });
+const startBtn = document.getElementById('start');
+const pauseBtn = document.getElementById('pause');
+const stopBtn = document.getElementById('stop');
+const delaySelect = document.getElementById('delay');
+const counter = document.getElementById('counter');
+const stateSpan = document.getElementById('state');
+const progress = document.getElementById('progress');
+
+startBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ action: 'start', delay: parseInt(delaySelect.value, 10) }, updateState);
 });
+
+pauseBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ action: 'pause' });
+});
+
+stopBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ action: 'stop' });
+});
+
+document.getElementById('close').addEventListener('click', () => window.close());
+
+function translate(status) {
+  switch (status) {
+    case 'running': return 'En cours';
+    case 'paused': return 'En pause';
+    case 'completed': return 'Terminé';
+    case 'stopped': return 'Arrêté';
+    case 'redirecting': return 'Redirection...';
+    default: return 'En attente';
+  }
+}
+
+function updateState(res) {
+  if (!res) return;
+  if (res.status) stateSpan.textContent = translate(res.status);
+}
+
+function refreshStatus() {
+  chrome.runtime.sendMessage({ action: 'status' }, state => {
+    if (!state) return;
+    counter.textContent = `${state.removed}/${state.total}`;
+    progress.max = state.total || 0;
+    progress.value = state.removed || 0;
+    stateSpan.textContent = translate(state.status);
+    pauseBtn.textContent = state.status === 'paused' ? 'Reprendre' : 'Pause';
+  });
+}
+
+setInterval(refreshStatus, 1000);
+refreshStatus();


### PR DESCRIPTION
## Summary
- redesign popup with start/pause/stop buttons, delay selector and progress display
- add status polling in popup.js
- implement pause/stop/status in background service worker
- auto redirect to the connections page when starting

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685eed93ea94832fa448edaed40489b0