### PR TITLE
Fix running counter when leaving connections page

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,82 +1,153 @@
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-  if (message.action === 'clean') {
-    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
-      var tab = tabs[0];
-      if (!tab || !tab.url || !tab.url.includes('linkedin.com/mynetwork/invite-connect/connections/')) {
-        chrome.scripting.executeScript({
-          target: { tabId: tab.id },
-          func: function() { alert('Veuillez naviguer vers votre page de connexions LinkedIn.'); }
-        }, function() {
-          sendResponse();
-        });
-        return true; // Keep the message channel open for async response
-      }
-      chrome.scripting.executeScript({
-        target: { tabId: tab.id },
-        func: function() {
-          function wait(ms) {
-            return new Promise(function(resolve) { setTimeout(resolve, ms); });
-          }
-          function randomDelay() { return 1500 + Math.random() * 500; }
-          if (!location.href.includes('linkedin.com/mynetwork/invite-connect/connections/')) {
-            alert('Veuillez naviguer vers votre page de connexions LinkedIn.');
-            return;
-          }
-          var cards = Array.prototype.slice.call(document.querySelectorAll('li.mn-connection-card'));
+const CONNECTIONS_PATH = 'linkedin.com/mynetwork/invite-connect/connections/';
 
-          function processCard(i) {
-            if (i >= cards.length) {
-              return;
-            }
-            var card = cards[i];
-            var moreBtn = card.querySelector(
-              "button.mn-connection-card__dropdown-trigger, " +
-              "button[aria-label*='More actions'], " +
-              "button[aria-label*='Plus d\\u2019actions'], " +
-              "button[aria-label*=\"Plus d'action\"]"
-            );
-            function continueNext() {
-              wait(randomDelay()).then(function() { processCard(i + 1); });
-            }
-            if (moreBtn) {
-              console.log('Opening actions menu for', card);
-              moreBtn.click();
-              wait(500).then(function() {
-                var removeBtn = document.querySelector(
-                  "div.mn-connection-card__dropdown-item button[aria-label*='Remove connection'], " +
-                  "div.mn-connection-card__dropdown-item button[aria-label*='Retirer la relation'], " +
-                  "div.mn-connection-card__dropdown-item button[aria-label*='Supprimer la relation'], " +
-                  "div.mn-connection-card__dropdown-item button[aria-label*='Supprimer']"
-                );
-                if (removeBtn) {
-                  console.log('Removing connection');
-                  removeBtn.click();
-                  wait(500).then(function() {
-                    var confirmBtn = document.querySelector(
-                      "button.artdeco-button--danger, button[aria-label*='Remove'], button[aria-label*='Retirer'], button[aria-label*='Supprimer']"
-                    );
-                    if (confirmBtn) {
-                      console.log('Confirming removal');
-                      confirmBtn.click();
-                    }
-                    continueNext();
-                  });
-                } else {
-                  continueNext();
-                }
-              });
-            } else {
-              continueNext();
-            }
-          }
+let state = {
+  status: 'idle',
+  removed: 0,
+  total: 0,
+  tabId: null,
+  delay: 1500
+};
 
-          processCard(0);
-        }
-      }, function() {
-        sendResponse();
-      });
-      return true; // Keep the message channel open for async response
+function isConnectionsPage(url) {
+  return url && url.includes(CONNECTIONS_PATH);
+}
+
+function stopProcess() {
+  if (state.tabId !== null) {
+    chrome.scripting.executeScript({
+      target: { tabId: state.tabId },
+      func: () => { window.__liCleanerStop = true; }
     });
-    return true;
+  }
+  state.status = 'stopped';
+  state.tabId = null;
+}
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tabId === state.tabId && changeInfo.status === 'loading') {
+    if (!isConnectionsPage(tab.url)) {
+      stopProcess();
+    }
   }
 });
+
+chrome.tabs.onRemoved.addListener(tabId => {
+  if (tabId === state.tabId) {
+    stopProcess();
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  switch (message.action) {
+    case 'start':
+      chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+        const tab = tabs[0];
+        if (!tab || !isConnectionsPage(tab.url)) {
+          sendResponse({ status: 'redirecting' });
+          return;
+        }
+        state.status = 'running';
+        state.removed = 0;
+        state.total = 0;
+        state.tabId = tab.id;
+        state.delay = message.delay || 1500;
+
+        chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          func: () => { window.__liCleanerStop = false; }
+        });
+
+        chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          func: contentScript,
+          args: [state.delay]
+        });
+        sendResponse({ status: state.status });
+      });
+      return true;
+    case 'status':
+      sendResponse(state);
+      break;
+    case 'stop':
+      stopProcess();
+      break;
+    case 'increment':
+      state.removed += 1;
+      break;
+    case 'total':
+      state.total = message.total;
+      break;
+    case 'completed':
+      state.status = 'completed';
+      state.tabId = null;
+      break;
+  }
+});
+
+function contentScript(delay) {
+  if (!location.href.includes('linkedin.com/mynetwork/invite-connect/connections/')) {
+    chrome.runtime.sendMessage({ action: 'completed' });
+    return;
+  }
+
+  const cards = Array.from(document.querySelectorAll('li.mn-connection-card'));
+  chrome.runtime.sendMessage({ action: 'total', total: cards.length });
+
+  function wait(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+  function randomDelay() { return delay + Math.floor(Math.random() * 500); }
+
+  let i = 0;
+  async function process() {
+    if (window.__liCleanerStop) {
+      chrome.runtime.sendMessage({ action: 'completed' });
+      return;
+    }
+    if (i >= cards.length) {
+      chrome.runtime.sendMessage({ action: 'completed' });
+      return;
+    }
+
+    const card = cards[i];
+    const moreBtn = card.querySelector(
+      "button.mn-connection-card__dropdown-trigger, " +
+      "button[aria-label*='More actions'], " +
+      "button[aria-label*='Plus d\\u2019actions'], " +
+      "button[aria-label*=\"Plus d'action\"]"
+    );
+
+    async function next() {
+      i += 1;
+      await wait(randomDelay());
+      process();
+    }
+
+    if (moreBtn) {
+      moreBtn.click();
+      await wait(500);
+      const removeBtn = document.querySelector(
+        "div.mn-connection-card__dropdown-item button[aria-label*='Remove connection'], " +
+        "div.mn-connection-card__dropdown-item button[aria-label*='Retirer la relation'], " +
+        "div.mn-connection-card__dropdown-item button[aria-label*='Supprimer la relation'], " +
+        "div.mn-connection-card__dropdown-item button[aria-label*='Supprimer']"
+      );
+      if (removeBtn) {
+        removeBtn.click();
+        await wait(500);
+        const confirmBtn = document.querySelector(
+          "button.artdeco-button--danger, button[aria-label*='Remove'], button[aria-label*='Retirer'], button[aria-label*='Supprimer']"
+        );
+        if (confirmBtn) {
+          confirmBtn.click();
+        }
+        chrome.runtime.sendMessage({ action: 'increment' });
+        await next();
+      } else {
+        await next();
+      }
+    } else {
+      await next();
+    }
+  }
+
+  process();
+}


### PR DESCRIPTION
## Summary
- update service worker logic in `background.js`
- stop deletion timer if the active tab is no longer the connections page
- keep track of progress for popup status

## Testing
- `node -e "new Function(require('fs').readFileSync('background.js','utf8'));"`

------
https://chatgpt.com/codex/tasks/task_b_685f0d101624832f82a26d9e10b9f4e3