### PR TITLE
Add basic Gmail notification system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,18 @@
-# LinkedIn Cleaner
+# Gmail Notifier
 
-*Take back control of your professional network with a single click.*
+*Receive desktop notifications for new Gmail messages.*
 
-LinkedIn Cleaner is a minimalist Chrome extension that helps you manage and clean your list of LinkedIn connections. It automatically removes connections displayed on the page while simulating human behavior with random pauses.
+This extension checks your Gmail inbox at regular intervals and alerts you when new emails arrive. Customize the badge color, notification sound and check interval.
 
 ## Installation
 1. Clone this repository.
-2. Open Chrome and go to `chrome://extensions`.
-3. Enable Developer mode and choose **Load unpacked** and select this folder.
+2. Open Chrome and navigate to `chrome://extensions`.
+3. Enable **Developer mode** and click **Load unpacked**, then select this folder.
 
-## Usage
-1. Navigate to your LinkedIn connections page: `https://www.linkedin.com/mynetwork/invite-connect/connections/`.
-2. Click the extension icon then **Start** to begin automatic removal.
-3. Use **Pause** or **Stop** to control the process. Visible contacts will be removed one by one. Reload the page to process another batch if necessary.
+## Options
+- **Check interval**: how often to poll Gmail.
+- **Badge color**: customize the toolbar badge.
+- **Notification sound**: choose among predefined sounds or upload your own (max 500KB).
 
-## Who is this extension for?
-- Professionals in career transition who want to refocus their network.
-- Active users whose connection list has become unmanageable.
-- Marketing and sales experts looking to refine their audience.
-- Anyone who values quality over quantity.
-
-## How it works
-The extension checks that you're on the connections page before running the script. It opens each contact's actions menu, clicks **Remove connection**, confirms the deletion and waits 1.5 to 2 seconds between contacts to mimic a human pace. The injection logic is now handled by a *service worker* for greater reliability, and the process automatically stops when you leave the connections page.
+## Permissions
+The extension requires access to `https://mail.google.com/*` to fetch your unread count and uses the Notifications and Storage APIs.

--- a/background.js
+++ b/background.js
@@ -1,206 +1,115 @@
-const CONNECTIONS_PATH = 'linkedin.com/mynetwork/invite-connect/connections/';
+const FEED_URL = 'https://mail.google.com/mail/feed/atom';
+const DEFAULT_INTERVAL = 60; // seconds
+let timer = null;
+let latestItems = [];
 
-let state = {
-  status: 'idle',
-  removed: 0,
-  total: 0,
-  tabId: null,
-  delay: 1500
-};
-
-function isConnectionsPage(url) {
-  return url && url.includes(CONNECTIONS_PATH);
+async function fetchFeed() {
+  try {
+    const res = await fetch(FEED_URL, { credentials: 'include' });
+    if (!res.ok) return null;
+    const text = await res.text();
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(text, 'application/xml');
+    const count = parseInt(xml.querySelector('fullcount').textContent, 10);
+    const entries = Array.from(xml.querySelectorAll('entry')).map(e => ({
+      title: e.querySelector('title').textContent,
+      author: e.querySelector('author > name').textContent,
+      summary: e.querySelector('summary') && e.querySelector('summary').textContent
+    }));
+    return { count, entries };
+  } catch (e) {
+    return null;
+  }
 }
 
-function stopProcess() {
-  if (state.tabId !== null) {
-    chrome.scripting.executeScript({
-      target: { tabId: state.tabId },
-      func: () => {
-        window.__liCleanerStop = true;
-        window.__liCleanerPause = false;
-      }
+function playSound(url) {
+  if (!url) return;
+  const audio = new Audio(url);
+  audio.play();
+}
+
+function showNotification(newCount) {
+  chrome.storage.sync.get(['notifySound'], prefs => {
+    chrome.notifications.create({
+      type: 'basic',
+      iconUrl: 'icons/icon48.png',
+      title: 'New Emails',
+      message: `You have ${newCount} new email(s).`
     });
-  }
-  state.status = 'stopped';
-  state.tabId = null;
+    playSound(prefs.notifySound);
+  });
 }
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (tabId === state.tabId && changeInfo.status === 'loading') {
-    if (!isConnectionsPage(tab.url)) {
-      stopProcess();
-    }
-  }
-});
-
-chrome.tabs.onRemoved.addListener(tabId => {
-  if (tabId === state.tabId) {
-    stopProcess();
-  }
-});
-
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  switch (message.action) {
-    case 'start':
-      chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
-        const tab = tabs[0];
-        if (!tab) { sendResponse(); return; }
-        const delay = message.delay || 1500;
-
-        const startCleaner = () => {
-          state.status = 'running';
-          state.removed = 0;
-          state.total = 0;
-          state.tabId = tab.id;
-          state.delay = delay;
-
-          chrome.scripting.executeScript({
-            target: { tabId: tab.id },
-            func: () => {
-              window.__liCleanerStop = false;
-              window.__liCleanerPause = false;
-            }
-          });
-
-          chrome.scripting.executeScript({
-            target: { tabId: tab.id },
-            func: contentScript,
-            args: [delay]
-          });
-        };
-
-        if (!isConnectionsPage(tab.url)) {
-          chrome.scripting.executeScript({
-            target: { tabId: tab.id },
-            func: () => confirm("You will be redirected to a new page. After the redirection, please click the 'Start' button again to continue the removal process.")
-          }, results => {
-            const proceed = results && results[0] && results[0].result;
-            if (!proceed) {
-              sendResponse({ status: 'idle' });
-              return;
-            }
-
-            state.status = 'redirecting';
-            chrome.tabs.update(tab.id, { url: 'https://www.linkedin.com/mynetwork/invite-connect/connections/' });
-            const listener = (id, info, updatedTab) => {
-              if (id === tab.id && info.status === 'complete' && isConnectionsPage(updatedTab.url)) {
-                chrome.tabs.onUpdated.removeListener(listener);
-                startCleaner();
-              }
-            };
-            chrome.tabs.onUpdated.addListener(listener);
-            sendResponse({ status: state.status });
-          });
-        } else {
-          startCleaner();
-          sendResponse({ status: state.status });
-        }
-      });
-      return true;
-    case 'status':
-      sendResponse(state);
-      break;
-    case 'pause':
-      if (state.tabId !== null) {
-        const shouldPause = state.status === 'running';
-        state.status = shouldPause ? 'paused' : 'running';
-        chrome.scripting.executeScript({
-          target: { tabId: state.tabId },
-          func: p => { window.__liCleanerPause = p; },
-          args: [shouldPause]
-        });
-      }
-      break;
-    case 'stop':
-      stopProcess();
-      break;
-    case 'increment':
-      state.removed += 1;
-      break;
-    case 'total':
-      state.total = message.total;
-      break;
-    case 'completed':
-      state.status = 'completed';
-      state.tabId = null;
-      break;
-  }
-});
-
-function contentScript(delay) {
-  if (!location.href.includes('linkedin.com/mynetwork/invite-connect/connections/')) {
-    chrome.runtime.sendMessage({ action: 'completed' });
-    return;
-  }
-
-  window.__liCleanerPause = false;
-
-  const cards = Array.from(document.querySelectorAll('li.mn-connection-card'));
-  chrome.runtime.sendMessage({ action: 'total', total: cards.length });
-
-  function wait(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
-  function randomDelay() { return delay + Math.floor(Math.random() * 500); }
-
-  let i = 0;
-  async function process() {
-    if (window.__liCleanerStop) {
-      chrome.runtime.sendMessage({ action: 'completed' });
-      return;
-    }
-    if (window.__liCleanerPause) {
-      setTimeout(process, 200);
-      return;
-    }
-    if (i >= cards.length) {
-      chrome.runtime.sendMessage({ action: 'completed' });
-      return;
-    }
-
-    const card = cards[i];
-    const moreBtn = card.querySelector(
-      "button.mn-connection-card__dropdown-trigger, " +
-      "button[aria-label*='More actions'], " +
-      "button[aria-label*='Plus d\\u2019actions'], " +
-      "button[aria-label*=\"Plus d'action\"]"
-    );
-
-    async function next() {
-      i += 1;
-      while (window.__liCleanerPause && !window.__liCleanerStop) {
-        await wait(200);
-      }
-      await wait(randomDelay());
-      process();
-    }
-
-    if (moreBtn) {
-      moreBtn.click();
-      await wait(500);
-      const removeBtn = document.querySelector(
-        "div.mn-connection-card__dropdown-item button[aria-label*='Remove connection'], " +
-        "div.mn-connection-card__dropdown-item button[aria-label*='Retirer la relation'], " +
-        "div.mn-connection-card__dropdown-item button[aria-label*='Supprimer la relation'], " +
-        "div.mn-connection-card__dropdown-item button[aria-label*='Supprimer']"
-      );
-      if (removeBtn) {
-        removeBtn.click();
-        await wait(500);
-        const confirmBtn = document.querySelector(
-          "button.artdeco-button--danger, button[aria-label*='Remove'], button[aria-label*='Retirer'], button[aria-label*='Supprimer']"
-        );
-        if (confirmBtn) {
-          confirmBtn.click();
-        }
-        chrome.runtime.sendMessage({ action: 'increment' });
-        await next();
-      } else {
-        await next();
-      }
-    } else {
-      await next();
-    }
-  }
-
-  process();
+function updateBadge(count, color) {
+  chrome.action.setBadgeBackgroundColor({ color });
+  chrome.action.setBadgeText({ text: count ? String(count) : '' });
 }
+
+async function checkMail() {
+  const data = await fetchFeed();
+  if (!data) return;
+  latestItems = data.entries;
+  chrome.storage.local.get('lastCount', store => {
+    const prev = store.lastCount || 0;
+    if (data.count > prev) {
+      showNotification(data.count - prev);
+    }
+    chrome.storage.local.set({ lastCount: data.count });
+  });
+  chrome.storage.sync.get({ badgeColor: '#D93025' }, prefs => {
+    updateBadge(data.count, prefs.badgeColor);
+  });
+}
+
+function startChecking() {
+  chrome.storage.sync.get({ checkInterval: DEFAULT_INTERVAL }, prefs => {
+    if (timer) clearInterval(timer);
+    timer = setInterval(checkMail, prefs.checkInterval * 1000);
+    checkMail();
+  });
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  createMenus();
+  startChecking();
+});
+
+chrome.storage.onChanged.addListener(changes => {
+  if (changes.checkInterval || changes.badgeColor) {
+    startChecking();
+  }
+});
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'refresh') {
+    checkMail();
+  } else if (msg.action === 'latest') {
+    sendResponse({ items: latestItems });
+  }
+});
+
+function createMenus() {
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({ id: 'open', title: 'Open Gmail', contexts: ['action'] });
+    chrome.contextMenus.create({ id: 'compose', title: 'Compose new message', contexts: ['action'] });
+    chrome.contextMenus.create({ id: 'refresh', title: 'Refresh now', contexts: ['action'] });
+    chrome.contextMenus.create({ id: 'options', title: 'Open settings', contexts: ['action'] });
+  });
+}
+
+chrome.contextMenus.onClicked.addListener(info => {
+  switch (info.menuItemId) {
+    case 'open':
+      chrome.tabs.create({ url: 'https://mail.google.com/' });
+      break;
+    case 'compose':
+      chrome.tabs.create({ url: 'https://mail.google.com/mail/?view=cm&fs=1&tf=1' });
+      break;
+    case 'refresh':
+      checkMail();
+      break;
+    case 'options':
+      chrome.runtime.openOptionsPage();
+      break;
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest_version": 3,
-  "name": "LinkedIn Cleaner",
-  "description": "Take back control of your professional network with a single click.",
+  "name": "Gmail Notifier",
+  "description": "Notify and preview new Gmail messages.",
   "version": "1.0",
-  "permissions": ["activeTab", "scripting", "tabs"],
-  "host_permissions": ["https://www.linkedin.com/*"],
+  "permissions": ["activeTab", "scripting", "tabs", "storage", "notifications", "contextMenus"],
+  "host_permissions": ["https://mail.google.com/*"],
   "background": {
     "service_worker": "background.js"
   },
   "action": {
     "default_popup": "popup.html",
-    "default_title": "LinkedIn Cleaner",
+    "default_title": "Gmail Notifier",
     "default_icon": {
       "16": "icons/icon16.png",
       "32": "icons/icon32.png",
@@ -23,5 +23,6 @@
     "32": "icons/icon32.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
-  }
+  },
+  "options_page": "options.html"
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Gmail Notifier Options</title>
+  <link rel="stylesheet" href="styles/options.css">
+</head>
+<body>
+  <h1>Gmail Notifier Settings</h1>
+  <label>
+    Check interval (seconds)
+    <input type="range" id="interval" min="30" max="600" step="30">
+    <span id="intervalValue"></span>
+  </label>
+  <label>
+    Badge color
+    <input type="color" id="badgeColor">
+  </label>
+  <label>
+    Notification sound
+    <select id="sound">
+      <option value="">Default</option>
+      <option value="sounds/notify1.ogg">Sound 1</option>
+      <option value="sounds/notify2.ogg">Sound 2</option>
+    </select>
+  </label>
+  <label>
+    Upload custom sound
+    <input type="file" id="customSound" accept=".mp3,.wav,.ogg">
+  </label>
+  <button id="save">Save</button>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,37 @@
+document.addEventListener('DOMContentLoaded', restore);
+document.getElementById('save').addEventListener('click', save);
+document.getElementById('interval').addEventListener('input', e => {
+  document.getElementById('intervalValue').textContent = e.target.value;
+});
+document.getElementById('customSound').addEventListener('change', handleSound);
+
+function restore() {
+  chrome.storage.sync.get({checkInterval:60, badgeColor:'#D93025', notifySound:''}, prefs => {
+    document.getElementById('interval').value = prefs.checkInterval;
+    document.getElementById('intervalValue').textContent = prefs.checkInterval;
+    document.getElementById('badgeColor').value = prefs.badgeColor;
+    document.getElementById('sound').value = prefs.notifySound;
+  });
+}
+
+function handleSound(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  if (file.size > 500 * 1024) {
+    alert('File too large');
+    e.target.value = '';
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = ev => {
+    document.getElementById('sound').value = ev.target.result;
+  };
+  reader.readAsDataURL(file);
+}
+
+function save() {
+  const interval = parseInt(document.getElementById('interval').value, 10);
+  const badgeColor = document.getElementById('badgeColor').value;
+  const sound = document.getElementById('sound').value;
+  chrome.storage.sync.set({checkInterval: interval, badgeColor, notifySound: sound});
+}

--- a/popup.html
+++ b/popup.html
@@ -2,42 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Automatic LinkedIn Connection Removal</title>
-  <style>
-    body { font-family: Arial, sans-serif; width: 300px; padding: 15px; background:#ffffff; color:#333; position:relative; }
-    h1 { font-size:18px; color:#0073b1; text-align:center; margin-top:0; }
-    label { font-size:14px; display:block; margin-bottom:4px; }
-    select, input[type=range] { width:100%; padding:5px; margin-bottom:10px; }
-    .range-wrap { display:flex; align-items:center; gap:8px; margin-bottom:10px; }
-    #delayValue { min-width:40px; text-align:right; }
-    .controls { display:flex; justify-content:space-between; margin-bottom:10px; }
-    button { flex:1; margin:0 2px; padding:8px; border:none; border-radius:4px; color:#fff; font-size:14px; cursor:pointer; }
-    #start { background:#28a745; }
-    #pause { background:#ff9800; }
-    #stop { background:#d32f2f; }
-    #close { position:absolute; top:5px; right:5px; border:none; background:none; font-size:16px; cursor:pointer; color:#999; }
-    #close:hover { color:#333; }
-    progress { width:100%; height:18px; margin-top:5px; }
-    .status { text-align:center; margin-top:5px; font-size:14px; }
-  </style>
+  <title>Gmail Notifier</title>
+  <link rel="stylesheet" href="styles/popup.css">
 </head>
 <body>
-  <button id="close">&times;</button>
-  <h1>Automatic LinkedIn Connection Removal</h1>
-  <label for="delay">Delay between removals</label>
-  <div class="range-wrap">
-    <input type="range" id="delay" min="1" max="60" value="2">
-    <span id="delayValue">2 sec</span>
-  </div>
-  <div class="controls">
-    <button id="start">Start</button>
-    <button id="pause">Pause</button>
-    <button id="stop">Stop</button>
-  </div>
-  <progress id="progress" value="0" max="0"></progress>
-  <div class="status">
-    <span id="counter">0/0</span> - <span id="state">Idle</span>
-  </div>
+  <div id="emails"></div>
+  <button id="open">Open Gmail</button>
+  <button id="refresh">Refresh</button>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,61 +1,20 @@
-const startBtn = document.getElementById('start');
-const pauseBtn = document.getElementById('pause');
-const stopBtn = document.getElementById('stop');
-const delayInput = document.getElementById('delay');
-const delayValue = document.getElementById('delayValue');
-const counter = document.getElementById('counter');
-const stateSpan = document.getElementById('state');
-const progress = document.getElementById('progress');
-
-function updateDelayDisplay() {
-  delayValue.textContent = `${delayInput.value} sec`;
-}
-
-updateDelayDisplay();
-
-delayInput.addEventListener('input', updateDelayDisplay);
-
-startBtn.addEventListener('click', () => {
-  const delayMs = parseInt(delayInput.value, 10) * 1000;
-  chrome.runtime.sendMessage({ action: 'start', delay: delayMs }, updateState);
+document.getElementById('open').addEventListener('click', () => {
+  chrome.tabs.create({ url: 'https://mail.google.com/' });
 });
 
-pauseBtn.addEventListener('click', () => {
-  chrome.runtime.sendMessage({ action: 'pause' });
+document.getElementById('refresh').addEventListener('click', () => {
+  chrome.runtime.sendMessage({ action: 'refresh' });
 });
 
-stopBtn.addEventListener('click', () => {
-  chrome.runtime.sendMessage({ action: 'stop' });
-});
-
-document.getElementById('close').addEventListener('click', () => window.close());
-
-function translate(status) {
-  switch (status) {
-    case 'running': return 'Running';
-    case 'paused': return 'Paused';
-    case 'completed': return 'Completed';
-    case 'stopped': return 'Stopped';
-    case 'redirecting': return 'Redirecting...';
-    default: return 'Idle';
+chrome.runtime.sendMessage({ action: 'latest' }, data => {
+  const emailsDiv = document.getElementById('emails');
+  if (!data || !data.items || data.items.length === 0) {
+    emailsDiv.textContent = 'No recent emails.';
+    return;
   }
-}
-
-function updateState(res) {
-  if (!res) return;
-  if (res.status) stateSpan.textContent = translate(res.status);
-}
-
-function refreshStatus() {
-  chrome.runtime.sendMessage({ action: 'status' }, state => {
-    if (!state) return;
-    counter.textContent = `${state.removed}/${state.total}`;
-    progress.max = state.total || 0;
-    progress.value = state.removed || 0;
-    stateSpan.textContent = translate(state.status);
-    pauseBtn.textContent = state.status === 'paused' ? 'Resume' : 'Pause';
+  data.items.slice(0, 3).forEach(item => {
+    const div = document.createElement('div');
+    div.textContent = `${item.author}: ${item.title}`;
+    emailsDiv.appendChild(div);
   });
-}
-
-setInterval(refreshStatus, 1000);
-refreshStatus();
+});

--- a/sounds/README.md
+++ b/sounds/README.md
@@ -1,0 +1,1 @@
+# Add notification sounds here

--- a/styles/options.css
+++ b/styles/options.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; padding: 20px; }
+label { display: block; margin-top: 10px; }
+#save { margin-top: 20px; }

--- a/styles/popup.css
+++ b/styles/popup.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; width: 200px; padding: 10px; }
+button { margin-top: 5px; width: 100%; }
+#emails { margin-bottom: 10px; }


### PR DESCRIPTION
## Summary
- switch project to a Gmail notifier extension
- implement background script to poll Gmail atom feed and push notifications
- add options page to control badge colour, sound and interval
- simple popup to list latest emails and access Gmail
- update manifest and README

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_685fc60f159c832fbd57fc7ee4ebf329